### PR TITLE
Downgraded Gradle to 8.7 via Wrapper task, updated SQL dependency and…

### DIFF
--- a/bandits-api/build.gradle
+++ b/bandits-api/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	runtimeOnly 'com.microsoft.sqlserver:mssql-jdbc'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/bandits-api/gradle/wrapper/gradle-wrapper.properties
+++ b/bandits-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/bandits-api/src/main/resources/application.properties
+++ b/bandits-api/src/main/resources/application.properties
@@ -1,1 +1,19 @@
 spring.application.name=bandits-api
+
+# Database connection settings
+spring.datasource.url=jdbc:mysql://localhost:3306/balanced_bytes
+spring.datasource.username=balanced_bytes
+spring.datasource.password=balanced_bytes
+
+# Specify the DBMS
+spring.jpa.database = MYSQL
+
+# Show or not log for each sql query
+spring.jpa.show-sql = true
+
+# Hibernate ddl auto (create, create-drop, update)
+spring.jpa.hibernate.ddl-auto = update
+
+# Use spring.jpa.properties.* for Hibernate native properties (the prefix is
+# stripped before adding them to the entity manager)
+spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
There is a [known issue](https://docs.gradle.org/8.8/release-notes.html#known-issues) with Gradle 8.8 and MacOS 11.x that was preventing me from running `spring boot`.  I updated the Gradle version via gradle-wrapper.properties, and subsequently needed to update a SQL dependency as well.  I also updated the application.settings with the settings I'm using for Workbench. The password is currently visible, but that should be fine for development and testing. Please pull this down when you get a chance and confirm that `spring boot` is working.