### PR TITLE
Removed index.css import from main.jsx

### DIFF
--- a/bandits-ui/src/main.jsx
+++ b/bandits-ui/src/main.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
-import './index.css'
 import CssBaseline from '@mui/material/CssBaseline'
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
Removed the line in main.jsx that was importing index.css. It's not currently being used, and the import is crashing the app on startup, since the file is missing.